### PR TITLE
Filter duplicates and empty lines on keyword creation

### DIFF
--- a/components/keywords/AddKeywords.tsx
+++ b/components/keywords/AddKeywords.tsx
@@ -34,8 +34,7 @@ const AddKeywords = ({ closeModal, domain, keywords }: AddKeywordsProps) => {
             setError(`Keywords ${keywordExist.join(',')} already Exist`);
             setTimeout(() => { setError(''); }, 3000);
          } else {
-            newKeywordsData.keywords = keywordsArray.join('\n');
-            addMutate(newKeywordsData);
+            addMutate({...newKeywordsData, keywords: keywordsArray.join('\n')});
          }
       } else {
          setError('Please Insert a Keyword');

--- a/components/keywords/AddKeywords.tsx
+++ b/components/keywords/AddKeywords.tsx
@@ -27,13 +27,14 @@ const AddKeywords = ({ closeModal, domain, keywords }: AddKeywordsProps) => {
 
    const addKeywords = () => {
       if (newKeywordsData.keywords) {
-         const keywordsArray = newKeywordsData.keywords.replaceAll('\n', ',').split(',').map((item:string) => item.trim());
+         const keywordsArray = [...new Set(newKeywordsData.keywords.split('\n').map((item) => item.trim()).filter((item) => !!item))];
          const currentKeywords = keywords.map((k) => `${k.keyword}-${k.device}-${k.country}`);
          const keywordExist = keywordsArray.filter((k) => currentKeywords.includes(`${k}-${newKeywordsData.device}-${newKeywordsData.country}`));
          if (keywordExist.length > 0) {
             setError(`Keywords ${keywordExist.join(',')} already Exist`);
             setTimeout(() => { setError(''); }, 3000);
          } else {
+            newKeywordsData.keywords = keywordsArray.join('\n');
             addMutate(newKeywordsData);
          }
       } else {


### PR DESCRIPTION
This should fix two minor issues:

- When creating new keywords, entering the same keywords multiple times will not lead to the creation of duplicate keywords.
- When creating new keywords, empty lines will not lead to the creation of empty keywords.