### PR TITLE
Removing capitalize to avoid incorrect representation of domains

### DIFF
--- a/components/domains/DomainItem.tsx
+++ b/components/domains/DomainItem.tsx
@@ -24,7 +24,7 @@ const DomainItem = ({ domain, selected, isConsoleIntegrated = false }: DomainIte
                   <img src={`https://image.thum.io/get/maxAge/96/width/200/https://${domain.domain}`} alt={domain.domain} />
                </div>
                <div className="domain_details flex-1">
-                  <h3 className='font-semibold text-base mb-2 capitalize'>{domain.domain}</h3>
+                  <h3 className='font-semibold text-base mb-2'>{domain.domain}</h3>
                  {keywordsUpdated && (
                   <span className=' text-gray-600 text-xs'>
                      Updated <TimeAgo title={dayjs(keywordsUpdated).format('DD-MMM-YYYY, hh:mm:ss A')} date={keywordsUpdated} />


### PR DESCRIPTION
Hey, 
first, thank you for this great project!

I find the representation of the domains as capitalize very unattractive/wrong. 
Domains should not be presented in this form, in my view.

Do you agree with me?

![image](https://user-images.githubusercontent.com/75305857/214341550-f300581a-7883-4868-99ad-de180b9d3b05.png)
![image](https://user-images.githubusercontent.com/75305857/214341513-40ffde97-cc97-40b2-b6df-78ab6b819414.png)


