### PR TITLE
Adding one-click deploy template for RepoCloud.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,8 @@ The App uses third party website scrapers like ScrapingAnt, ScrapingRobot, Searc
 **Stack**
 -   Next.js for Frontend & Backend.  
 -   Sqlite for Database.
+
+#### One-Click Deployment
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=181)
+


### PR DESCRIPTION
Link to one-click installation template enabling users to affordably deploy and scale SerpBear on RepoCloud's efficient cloud hosting platform. Placing this link on the readme qualifies the SerpBear team to earn 25% recurring referral commission.