### PR TITLE
fix: Correct CTR calculation in InsightStats component

### DIFF
--- a/components/insight/InsightStats.tsx
+++ b/components/insight/InsightStats.tsx
@@ -13,16 +13,20 @@ type InsightStatsProps = {
 }
 
 const InsightStats = ({ stats = [], totalKeywords = 0, totalPages = 0 }:InsightStatsProps) => {
-   const totalStat = useMemo(() => {
-      return stats.reduce((acc, item) => {
-         return {
+    const totalStat = useMemo(() => {
+      const totals = stats.reduce((acc, item) => {
+          return {
             impressions: item.impressions + acc.impressions,
             clicks: item.clicks + acc.clicks,
-            ctr: item.ctr + acc.ctr,
             position: item.position + acc.position,
-         };
-      }, { impressions: 0, clicks: 0, ctr: 0, position: 0 });
-   }, [stats]);
+          };
+      }, { impressions: 0, clicks: 0, position: 0 });
+    
+      return {
+          ...totals,
+          ctr: totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : 0
+      };
+    }, [stats]);
 
    const chartData = useMemo(() => {
       const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];


### PR DESCRIPTION
Issue at #233 

The CTR calculation was incorrectly summing up individual CTR values, resulting in inflated percentages. Now calculates CTR properly by dividing total clicks by total impressions.

Previous Implementation:
- CTR was calculated by adding up individual CTR percentages
- This resulted in artificially high CTR values
- For example: [10%, 15%, 20%] => 45% (incorrect)

New Implementation:
- CTR is now calculated using (total clicks / total impressions) * 100
- This provides the actual click-through rate across all data
- For example: (50 clicks / 1000 impressions) * 100 = 5% (correct)

This fix ensures accurate CTR reporting in the analytics dashboard.

Changes:
- Removed CTR accumulation from reducer
- Added proper CTR calculation based on total clicks and impressions
- Maintains better statistical accuracy in reporting