### PR TITLE
Add error message, if returned search HTML does not contain required elements

### DIFF
--- a/scrapers/services/proxy.ts
+++ b/scrapers/services/proxy.ts
@@ -16,6 +16,13 @@ const proxy:ScraperSettings = {
 
       const $ = cheerio.load(content);
       let lastPosition = 0;
+      const hasValidContent = $('body').find('#main')
+      if (hasValidContent.length == 0) {
+         const msg = '[ERROR] Scraped search results from proxy do not adhere to expected format. Unable to parse results';
+         console.log(msg);
+         throw new Error(msg);
+      }
+
       const mainContent = $('body').find('#main');
       const children = $(mainContent).find('h3');
 

--- a/utils/scraper.ts
+++ b/utils/scraper.ts
@@ -127,6 +127,8 @@ export const scrapeKeywordFromGoogle = async (keyword:KeywordType, settings:Sett
       refreshedResults.error = scraperError || 'Unknown Error';
       if (settings.scraper_type === 'proxy' && error && error.response && error.response.statusText) {
          refreshedResults.error = `[${error.response.status}] ${error.response.statusText}`;
+      } else if (settings.scraper_type === 'proxy' && error) {
+         refreshedResults.error = error;
       }
 
       console.log('[ERROR] Scraping Keyword : ', keyword.keyword);


### PR DESCRIPTION
## Change
This change adds a check, if the returned HTML from non-SERP scrapers like scraping robot or proxy contains the expected base structure. 

This improves the problem from #272 where parsing fails on a bot-protection popup and returns position = 0.
The error that no results can be parsed on bot-protection still persists, but serpbear will show an error instead of dropping position to zero. 

## Behavior
- If the returned HTML is no valid search result: An error is raised
- If the returned HTML is valid, but the search has 0 results: Behavior unchanged - no Error and results = 0

## Screenshot of changed version on error
Note, that the drop in the position graph was generated due to #272 and should not occur anymore with this change.
![image](https://github.com/user-attachments/assets/604c35cc-22b6-4117-93a9-d1977ffc3644)

## Log of changed version on error
```
serpbear  | [0] POST /api/refresh?id=5
serpbear  | [0] keywordIDs:  [ 5 ]
serpbear  | [0] START SCRAPE:  mykeword
serpbear  | [0] GET /api/keywords?domain=mydomain.de
serpbear  | [0] [ERROR] Scraped search results do not adhere to expected format. Unable to parse results
serpbear  | [0] [ERROR] Scraping Keyword :  mykeword
serpbear  | [0] [ERROR_MESSAGE]:  Error: [ERROR] Scraped search results do not adhere to expected format. Unable to parse results
serpbear  | [0]     at extractScrapedResult (/app/.next/server/chunks/941.js:322:15)
serpbear  | [0]     at scrapeKeywordFromGoogle (/app/.next/server/chunks/941.js:277:100)
serpbear  | [0]     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
serpbear  | [0]     at async refreshAndUpdateKeyword (/app/.next/server/chunks/941.js:79:34)
serpbear  | [0]     at async refreshAndUpdateKeywords (/app/.next/server/chunks/941.js:59:37)
serpbear  | [0] [SUCCESS] Updating the Keyword:  mykeword
serpbear  | [0] time taken: 2985.039358ms
```