### PR TITLE
make entrypoint executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/cron.js ./
 COPY --from=builder --chown=nextjs:nodejs /app/email ./email
 COPY --from=builder --chown=nextjs:nodejs /app/database ./database
 COPY --from=builder --chown=nextjs:nodejs /app/.sequelizerc ./.sequelizerc
-COPY --from=builder --chown=nextjs:nodejs /app/entrypoint.sh ./entrypoint.sh
+COPY --from=builder --chown=nextjs:nodejs --chmod=770 /app/entrypoint.sh ./entrypoint.sh
 RUN rm package.json
 RUN npm init -y 
 RUN npm i cryptr@6.0.3 dotenv@16.0.3 croner@9.0.0 @googleapis/searchconsole@1.0.5 sequelize-cli@6.6.2 @isaacs/ttlcache@1.4.1


### PR DESCRIPTION
When trying to build & run the `Dockerfile` in it's current version, I came across the problem, that the entrypoint was not executable.

This results in the error:
```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/app/entrypoint.sh": permission denied: unknown.
```

I am unsure if this ever worked in other environments, or if something like the default-mode changed in the base image.
Nevertheless, this change ensures the entrypoint is copied with the right permissions.