### PR TITLE
feat: add env enabling POST to keyword

### DIFF
--- a/utils/verifyUser.ts
+++ b/utils/verifyUser.ts
@@ -24,6 +24,11 @@ const verifyUser = (req: NextApiRequest, res: NextApiResponse): string => {
       'GET:/api/searchconsole',
       'GET:/api/insight',
    ];
+
+   if (process.env.ALLOW_KEYWORD_POST) {
+      allowedApiRoutes.push('POST:/api/keywords'); 
+   }
+   
    const verifiedAPI = req.headers.authorization ? req.headers.authorization.substring('Bearer '.length) === process.env.APIKEY : false;
    const accessingAllowedRoute = req.url && req.method && allowedApiRoutes.includes(`${req.method}:${req.url.replace(/\?(.*)/, '')}`);
    console.log(req.method, req.url);


### PR DESCRIPTION
More for discussion, regarding #57 and #289. I forked the repo, added this ENV to allow the `POST /api/keyword` route, and it just works. Is there something fundamental I'm missing here or is this a reasonable change?

I plan to use this to enable some automation that pulls keywords from reports already generated by my marketing team, and adds them to tracking here. 

Can merge this if the maintainers are interested in having it in main, happy to make any changes / write tests